### PR TITLE
fix(lodash) bumping lodash to a more secure version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "async": "^0.9.0",
-    "lodash": "^2.4.1",
+    "lodash": "4.17.5",
     "soap": "git://github.com/datahero/node-soap.git#689a0ed7d24de4597fb0e71396f3b70c69245bb3"
   }
 }


### PR DESCRIPTION
There's a security vulnerability in versions of lodash previous to 4.17.5. 
The functions causing vulnerability are not used in this package. The functions that are used are unchanged in the newer version of lodash, so bumping the version should cause no problems, and using a more secure version is generally preferable.

https://snyk.io/test/npm/lodash/2.4.1